### PR TITLE
Update keynotes speakers schedule and add agenda section

### DIFF
--- a/src/components/EventAgenda.tsx
+++ b/src/components/EventAgenda.tsx
@@ -85,7 +85,10 @@ export default function EventAgenda({ data }: Props) {
   };
 
   return (
-    <section className="relative z-10 bg-[#080814] bg-gradient-to-b py-12 text-white">
+    <section
+      id="agenda"
+      className="relative z-10 bg-[#080814] bg-gradient-to-b py-12 text-white"
+    >
       <div className="container mx-auto">
         <div className="mx-auto">
           {/* Section Header */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,10 +23,10 @@ export default function Header() {
       name: "Speakers",
       href: "#speakers",
     },
-    // {
-    //   name: "Highlight",
-    //   href: "#highlight",
-    // },
+    {
+      name: "Agenda",
+      href: "#agenda",
+    },
     {
       name: "FAQ",
       href: "#faq",

--- a/src/data/agenda.json
+++ b/src/data/agenda.json
@@ -55,48 +55,48 @@
       },
       {
         "time_start": "13:40",
-        "time_end": "14:10",
+        "time_end": "14:25",
+        "title": "Keynote by Ayu Purwarianti",
+        "speakers": ["Ayu Purwarianti"],
+        "type": "keynote"
+      },
+      {
+        "time_start": "14:30",
+        "time_end": "15:00",
         "title": "Build, Share, Connect: Perlihatkan karyamu",
         "speakers": ["Hilman Ramadhan"],
         "type": "talks"
       },
       {
-        "time_start": "14:15",
-        "time_end": "14:45",
-        "title": "Certified Answers for RAG: Cryptographic Receipts that Prove What Your AI Says",
-        "speakers": ["Renaldi Gondosubroto"],
-        "type": "talks"
-      },
-      {
-        "time_start": "14:45",
-        "time_end": "15:15",
+        "time_start": "15:00",
+        "time_end": "15:30",
         "title": "Coffee Break",
         "speakers": null,
         "type": "break"
       },
       {
-        "time_start": "15:15",
-        "time_end": "15:45",
-        "title": "Discussion Panel with Bagas & Gogo",
-        "speakers": ["Bagas Naufal Insani"],
+        "time_start": "15:30",
+        "time_end": "16:00",
+        "title": "Certified Answers for RAG: Cryptographic Receipts that Prove What Your AI Says (Research, Deep-dive)",
+        "speakers": ["Renaldi Gondosubroto"],
         "type": "talks"
       },
       {
-        "time_start": "15:50",
-        "time_end": "16:10",
+        "time_start": "16:05",
+        "time_end": "16:25",
         "title": "Our sponsors: TrueWatch",
         "speakers": null,
         "type": "sponsors"
       },
       {
-        "time_start": "16:15",
-        "time_end": "17:00",
-        "title": "Keynote by Sandhika Galih",
-        "speakers": ["Sandhika Galih"],
+        "time_start": "16:30",
+        "time_end": "17:30",
+        "title": "Discussion Panel with Bagas & Gogo",
+        "speakers": ["Bagas Naufal Insani", "Listiarso Wastuargo"],
         "type": "keynote"
       },
       {
-        "time_start": "17:00",
+        "time_start": "17:30",
         "time_end": null,
         "title": "Closing Remark",
         "speakers": null,
@@ -133,8 +133,8 @@
       {
         "time_start": "10:35",
         "time_end": "11:20",
-        "title": "Keynote by Ayu Purwarianti",
-        "speakers": ["Ayu Purwarianti"],
+        "title": "Keynote by Sandhika Galih",
+        "speakers": ["Sandhika Galih"],
         "type": "keynote"
       },
       {
@@ -180,28 +180,28 @@
         "type": "break"
       },
       {
-        "time_start": "15:35",
-        "time_end": "16:05",
+        "time_start": "15:30",
+        "time_end": "16:00",
         "title": "Lightning Talks (6 @ 5 min)",
         "speakers": null,
         "type": "talks"
       },
       {
-        "time_start": "16:10",
-        "time_end": "16:55",
+        "time_start": "16:05",
+        "time_end": "16:50",
         "title": "Keynote by Rendy B. Junior",
         "speakers": ["Rendy B. Junior"],
         "type": "keynote"
       },
       {
         "time_start": "16:55",
-        "time_end": "17:10",
+        "time_end": "17:05",
         "title": "Doorprize Announcement",
         "speakers": null,
         "type": "others"
       },
       {
-        "time_start": "17:10",
+        "time_start": "17:05",
         "time_end": null,
         "title": "Closing Remark",
         "speakers": null,


### PR DESCRIPTION
<img width="1208" height="1043" alt="Screenshot 2025-11-10 at 08 30 08" src="https://github.com/user-attachments/assets/9067c65a-d204-44a3-bc16-5e7b13af850b" />

<img width="1229" height="581" alt="Screenshot 2025-11-10 at 08 30 44" src="https://github.com/user-attachments/assets/674535b7-ea7a-4ec7-9a05-e84b1a65bd17" />

## What
Add Agenda section link in the Header and update agenda data with revised session timings and speaker lineup.

## Why
The Agenda section needed to be accessible directly from the navigation for better user experience, and the event schedule required updates to reflect the latest confirmed sessions, speakers, and timing adjustments.

## How
- Added `id="agenda"` to the `<section>` element in `EventAgenda.tsx` to enable anchor linking.  
- Updated `Header.tsx` to include a new "Agenda" menu item linking to `#agenda`.  
- Revised `agenda.json`:
  - Adjusted several session start/end times for better pacing.  
  - Updated talk titles and reordered sessions.  
  - Swapped keynote speakers (Ayu Purwarianti ↔ Sandhika Galih).  
  - Updated panel discussion and break timings.  
  - Revised closing segments to match the updated timeline.