### PR TITLE
Extend opening, open the gate earlier

### DIFF
--- a/src/data/agenda.json
+++ b/src/data/agenda.json
@@ -5,7 +5,7 @@
     "active": true,
     "agendas": [
       {
-        "time_start": "09:00",
+        "time_start": "08:30",
         "time_end": null,
         "title": "Gate open (registration)",
         "speakers": null,
@@ -13,90 +13,90 @@
       },
       {
         "time_start": "10:00",
-        "time_end": "10:05",
+        "time_end": "10:10",
         "title": "Opening",
         "speakers": null,
         "type": "others"
       },
       {
-        "time_start": "10:10",
-        "time_end": "10:30",
+        "time_start": "10:15",
+        "time_end": "10:35",
         "title": "Real-Time Web Search for AI tools",
         "speakers": ["Hilman Ramadhan"],
         "type": "sponsors"
       },
       {
-        "time_start": "10:35",
-        "time_end": "11:20",
+        "time_start": "10:40",
+        "time_end": "11:25",
         "title": "Keynote by Pahlevi Fikri Auliya",
         "speakers": ["Pahlevi Fikri Auliya"],
         "type": "keynote"
       },
       {
-        "time_start": "11:25",
-        "time_end": "11:55",
+        "time_start": "11:30",
+        "time_end": "12:00",
         "title": "Under the Hood: Building AI Coding Assistants, Understand the Mechanics to Unleash Their Power",
         "speakers": ["Yohan Totting"],
         "type": "talks"
       },
       {
-        "time_start": "12:00",
-        "time_end": "12:30",
+        "time_start": "12:05",
+        "time_end": "12:35",
         "title": "Balancing AI Innovation & Profit: The CTO Playbook for Two-Speed Organizations",
         "speakers": ["Evan Purnama"],
         "type": "talks"
       },
       {
-        "time_start": "12:30",
-        "time_end": "13:40",
+        "time_start": "12:35",
+        "time_end": "13:45",
         "title": "Lunch Break",
         "speakers": null,
         "type": "break"
       },
       {
-        "time_start": "13:40",
-        "time_end": "14:25",
+        "time_start": "13:45",
+        "time_end": "14:30",
         "title": "Keynote by Ayu Purwarianti",
         "speakers": ["Ayu Purwarianti"],
         "type": "keynote"
       },
       {
-        "time_start": "14:30",
-        "time_end": "15:00",
+        "time_start": "14:35",
+        "time_end": "15:05",
         "title": "Build, Share, Connect: Perlihatkan karyamu",
         "speakers": ["Hilman Ramadhan"],
         "type": "talks"
       },
       {
-        "time_start": "15:00",
-        "time_end": "15:30",
+        "time_start": "15:05",
+        "time_end": "15:35",
         "title": "Coffee Break",
         "speakers": null,
         "type": "break"
       },
       {
-        "time_start": "15:30",
-        "time_end": "16:00",
+        "time_start": "15:35",
+        "time_end": "16:05",
         "title": "Certified Answers for RAG: Cryptographic Receipts that Prove What Your AI Says (Research, Deep-dive)",
         "speakers": ["Renaldi Gondosubroto"],
         "type": "talks"
       },
       {
-        "time_start": "16:05",
-        "time_end": "16:25",
+        "time_start": "16:10",
+        "time_end": "16:30",
         "title": "Hidden LLM Failures and How to Find Them",
         "speakers": ["Agung Darmawan"],
         "type": "sponsors"
       },
       {
-        "time_start": "16:30",
-        "time_end": "17:30",
+        "time_start": "16:35",
+        "time_end": "17:35",
         "title": "Discussion Panel with Bagas & Gogo",
         "speakers": ["Bagas Naufal Insani", "Listiarso Wastuargo"],
         "type": "keynote"
       },
       {
-        "time_start": "17:30",
+        "time_start": "17:35",
         "time_end": null,
         "title": "Closing Remark",
         "speakers": null,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ const regularSpeakers = speakersData.filter((speaker) => speaker.type === "regul
           <BlurFade delay={0.6} client:load>
             <div class="my-8">
               <span class="bg-[#32598B] px-3 py-2 text-sm text-[#D9DFE9] sm:px-8 sm:text-base">
-                <NumberTicker value={12} delay={0} className="text-sm text-[#D9DFE9] sm:text-base" client:load /> Speakers
+                <NumberTicker value={14} delay={0} className="text-sm text-[#D9DFE9] sm:text-base" client:load /> Speakers
                 Will Talk About Artificial Intelligence
               </span>
             </div>


### PR DESCRIPTION
## What
Update agenda timings across the event schedule and adjust the displayed speaker count.

<img width="1062" height="476" alt="Screenshot 2025-11-17 at 09 04 53" src="https://github.com/user-attachments/assets/edcddb01-0c16-49be-ac18-9fb8cba8f5d1" />


## How
- Shift multiple agenda `time_start` and `time_end` entries to new confirmed times.  
- Increase speaker count in `index.astro` from 12 to 14 to match the latest data.  